### PR TITLE
Fix Railway deployment configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ type TestConfig struct {
 func Load() *Config {
 	return &Config{
 		Server: ServerConfig{
-			APIPort:       getEnvInt("VPN_API_PORT", 8443),
+			APIPort:       getEnvInt("PORT", getEnvInt("VPN_API_PORT", 8443)),
 			VPNPort:       getEnvInt("VPN_LISTEN_PORT", 51820),
 			InterfaceName: getEnvString("VPN_INTERFACE", "wg0"),
 		},

--- a/railway.json
+++ b/railway.json
@@ -1,13 +1,11 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "nixpacks",
-    "buildCommand": "go build -o server ./cmd/server"
+    "builder": "dockerfile"
   },
   "deploy": {
-    "startCommand": "./server",
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 100,
+    "healthcheckTimeout": 300,
     "restartPolicyType": "always"
   }
 }


### PR DESCRIPTION
- Use Dockerfile builder instead of nixpacks
- Prioritize Railway's PORT environment variable over VPN_API_PORT
- Increase health check timeout to 300 seconds
- Remove redundant startCommand (Dockerfile already defines ENTRYPOINT)

This should fix the health check failures by ensuring the app listens on Railway's expected port.

🤖 Generated with [Claude Code](https://claude.ai/code)