### PR TITLE
Fix remote VPN server endpoint and Windows routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ docker-compose.override.yml
 # Logs
 *.log
 
+# Runtime data
+data/
+
 # Claude Code personal settings
 .claude/settings.local.json
 .claude/*.local.*

--- a/Makefile
+++ b/Makefile
@@ -85,16 +85,23 @@ fmt:
 
 
 clean:
+	@echo "Cleaning build artifacts and VPN data..."
 ifeq ($(OS),Windows_NT)
 	@if exist bin rmdir /s /q bin 2>nul || true
 	@if exist coverage.out del coverage.out 2>nul || true
 	@if exist coverage.html del coverage.html 2>nul || true
+	@if exist data rmdir /s /q data 2>nul || true
+	@if exist %USERPROFILE%\.go-wire-vpn rmdir /s /q "%USERPROFILE%\.go-wire-vpn" 2>nul || true
 else
 	rm -rf bin/
 	rm -f coverage.out coverage.html
+	rm -rf data/
+	rm -rf ~/.go-wire-vpn/
 endif
+	@echo "VPN connections reset - clients need to re-register"
 
 clean-all: clean
+	@echo "Cleaning downloaded libraries..."
 ifeq ($(OS),Windows_NT)
 	@if exist lib rmdir /s /q lib 2>nul || true
 else
@@ -133,7 +140,7 @@ help:
 	@echo "  deps              - Verify and download dependencies"
 	@echo "  lint              - Run linter"
 	@echo "  fmt               - Format code"
-	@echo "  clean             - Clean build artifacts"
-	@echo "  clean-all         - Clean build artifacts and downloaded libs"
+	@echo "  clean             - Clean build artifacts and VPN data (reset connections)"
+	@echo "  clean-all         - Clean build artifacts, VPN data, and downloaded libs"
 	@echo "  download-wintun   - Download WinTun DLLs for Windows support"
 	@echo "  help              - Show this help"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,10 +102,22 @@ func handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Extract server VPN IP from ServerIP (remove /24)
 	serverVPNIP := strings.Split(serverInfo.ServerIP, "/")[0]
 
+	// Auto-detect public endpoint if not configured
+	endpoint := serverInfo.Endpoint
+	if endpoint == "" || strings.HasPrefix(endpoint, ":") {
+		// Extract the host from the request to determine public IP
+		host := r.Host
+		if strings.Contains(host, ":") {
+			host = strings.Split(host, ":")[0]
+		}
+		// Use the host the client connected to with the VPN port
+		endpoint = fmt.Sprintf("%s:%d", host, cfg.Server.VPNPort)
+	}
+	
 	// Return connection details
 	response := RegisterResponse{
 		ServerPublicKey: serverInfo.PublicKey,
-		ServerEndpoint:  serverInfo.Endpoint,
+		ServerEndpoint:  endpoint,
 		ServerVPNIP:     serverVPNIP,
 		ServerAPIPort:   cfg.Server.APIPort,
 		ClientIP:        clientIP + "/32",

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -113,7 +113,7 @@ func handleRegister(w http.ResponseWriter, r *http.Request) {
 		// Use the host the client connected to with the VPN port
 		endpoint = fmt.Sprintf("%s:%d", host, cfg.Server.VPNPort)
 	}
-	
+
 	// Return connection details
 	response := RegisterResponse{
 		ServerPublicKey: serverInfo.PublicKey,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,6 +27,8 @@ type RegisterRequest struct {
 type RegisterResponse struct {
 	ServerPublicKey string `json:"serverPublicKey"`
 	ServerEndpoint  string `json:"serverEndpoint"`
+	ServerVPNIP     string `json:"serverVPNIP"`   // Server's IP within VPN network
+	ServerAPIPort   int    `json:"serverAPIPort"` // Server's API port
 	ClientIP        string `json:"clientIP"`
 	Message         string `json:"message"`
 	Timestamp       string `json:"timestamp"`
@@ -97,10 +99,15 @@ func handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("Client registered successfully", "clientIP", clientIP)
 
+	// Extract server VPN IP from ServerIP (remove /24)
+	serverVPNIP := strings.Split(serverInfo.ServerIP, "/")[0]
+
 	// Return connection details
 	response := RegisterResponse{
 		ServerPublicKey: serverInfo.PublicKey,
 		ServerEndpoint:  serverInfo.Endpoint,
+		ServerVPNIP:     serverVPNIP,
+		ServerAPIPort:   cfg.Server.APIPort,
 		ClientIP:        clientIP + "/32",
 		Message:         "Registration successful - VPN tunnel established",
 		Timestamp:       time.Now().UTC().Format(time.RFC3339),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -179,10 +179,11 @@ func main() {
 	}
 
 	serverConfig := vpnserver.ServerConfig{
-		InterfaceName: cfg.Server.InterfaceName,
-		PrivateKey:    serverPrivateKey,
-		ListenPort:    cfg.Server.VPNPort,
-		ServerIP:      cfg.Network.ServerIP,
+		InterfaceName:  cfg.Server.InterfaceName,
+		PrivateKey:     serverPrivateKey,
+		ListenPort:     cfg.Server.VPNPort,
+		ServerIP:       cfg.Network.ServerIP,
+		PublicEndpoint: cfg.Server.PublicEndpoint,
 	}
 
 	// Start VPN server

--- a/cmd/vpn-cli/main.go
+++ b/cmd/vpn-cli/main.go
@@ -110,6 +110,8 @@ type RegisterRequest struct {
 type RegisterResponse struct {
 	ServerPublicKey string `json:"serverPublicKey"`
 	ServerEndpoint  string `json:"serverEndpoint"`
+	ServerVPNIP     string `json:"serverVPNIP"`   // Server's IP within VPN network
+	ServerAPIPort   int    `json:"serverAPIPort"` // Server's API port
 	ClientIP        string `json:"clientIP"`
 	Message         string `json:"message"`
 	Timestamp       string `json:"timestamp"`
@@ -168,6 +170,8 @@ func runRegister(serverURL string) error {
 		ClientPublicKey:  clientPubKey,
 		ServerPublicKey:  registerResp.ServerPublicKey,
 		ServerEndpoint:   registerResp.ServerEndpoint,
+		ServerVPNIP:      registerResp.ServerVPNIP,
+		ServerAPIPort:    registerResp.ServerAPIPort,
 		ClientIP:         registerResp.ClientIP,
 		RegisteredAt:     time.Now(),
 	}
@@ -285,8 +289,8 @@ func runTestVPN() error {
 	}
 
 	// Try to access the VPN test endpoint through the tunnel
-	// Use the VPN server's internal IP to test through the tunnel
-	testURL := "http://10.0.0.1:8443/api/vpn-test"
+	// Use the server's VPN IP and API port from saved configuration
+	testURL := fmt.Sprintf("http://%s:%d/api/vpn-test", clientConfig.ServerVPNIP, clientConfig.ServerAPIPort)
 	fmt.Printf("Testing VPN endpoint: %s\n", testURL)
 
 	resp, err := http.Get(testURL)

--- a/cmd/vpn-cli/main.go
+++ b/cmd/vpn-cli/main.go
@@ -284,8 +284,9 @@ func runTestVPN() error {
 		serverEndpoint = "localhost" + serverEndpoint
 	}
 
-	// Try to access the VPN test endpoint
-	testURL := "http://localhost:8443/api/vpn-test"
+	// Try to access the VPN test endpoint through the tunnel
+	// Use the VPN server's internal IP to test through the tunnel
+	testURL := "http://10.0.0.1:8443/api/vpn-test"
 	fmt.Printf("Testing VPN endpoint: %s\n", testURL)
 
 	resp, err := http.Get(testURL)

--- a/data/peers.json
+++ b/data/peers.json
@@ -1,7 +1,0 @@
-{
-  "swttP7nhURoXVZYxLAzhNp9hkrZAxEA83YJhv4XRw3c=": {
-    "publicKey": "swttP7nhURoXVZYxLAzhNp9hkrZAxEA83YJhv4XRw3c=",
-    "allowedIPs": "10.0.0.100/32",
-    "registeredAt": "2025-08-25T13:58:03.1471454+03:00"
-  }
-}

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -128,8 +129,13 @@ func setWindowsHidden(path string) error {
 		return nil
 	}
 
+	// TODO: Implement proper Windows ACL management
+	// For now, log a warning about reduced security
+	log.Printf("WARNING: Config file security on Windows is reduced - implement proper ACLs for production")
+	
 	// Note: This is a simplified implementation
 	// Production code should use Windows APIs for proper ACL management
+	// to set appropriate file permissions and deny access to other users
 	return nil
 }
 

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -20,6 +20,8 @@ type ClientConfig struct {
 	// Server connection details
 	ServerPublicKey string `json:"serverPublicKey"`
 	ServerEndpoint  string `json:"serverEndpoint"`
+	ServerVPNIP     string `json:"serverVPNIP"`   // Server's IP within VPN network
+	ServerAPIPort   int    `json:"serverAPIPort"` // Server's API port
 	ClientIP        string `json:"clientIP"`
 
 	// Registration metadata
@@ -132,7 +134,7 @@ func setWindowsHidden(path string) error {
 	// TODO: Implement proper Windows ACL management
 	// For now, log a warning about reduced security
 	log.Printf("WARNING: Config file security on Windows is reduced - implement proper ACLs for production")
-	
+
 	// Note: This is a simplified implementation
 	// Production code should use Windows APIs for proper ACL management
 	// to set appropriate file permissions and deny access to other users

--- a/internal/client/tunnel/tunnel.go
+++ b/internal/client/tunnel/tunnel.go
@@ -415,15 +415,23 @@ func (tm *TunnelManager) configureFullTrafficRouting() error {
 
 	fmt.Printf("Current routing table:\n%s\n", string(output))
 
-	// For now, show what would be configured rather than actually changing routes
-	// This prevents breaking the user's internet connection during testing
-	fmt.Println("⚠️  Full routing configuration would:")
-	fmt.Println("   1. Add route for VPN server via current gateway")
-	fmt.Println("   2. Replace default route (0.0.0.0/0) to go through VPN")
-	fmt.Println("   3. Configure DNS to use VPN-provided DNS servers")
+	// Add basic VPN subnet routing to allow communication with VPN server
+	fmt.Println("⚠️  Configuring basic VPN subnet routing (10.0.0.0/24)...")
+
+	// Add route for VPN subnet through the TUN interface
+	// This allows pinging 10.0.0.1 (server) through the VPN tunnel
+	routeCmd := exec.Command("route", "add", "10.0.0.0", "mask", "255.255.255.0", "10.0.0.100", "metric", "1")
+	if err := routeCmd.Run(); err != nil {
+		fmt.Printf("⚠️  Failed to add VPN subnet route: %v\n", err)
+		fmt.Println("   You may need to run as administrator")
+	} else {
+		fmt.Println("✅ VPN subnet routing configured (10.0.0.0/24)")
+	}
+
 	fmt.Println()
-	fmt.Println("💡 This is disabled for safety during local testing.")
-	fmt.Println("   Deploy to production environment to enable full VPN routing.")
+	fmt.Println("💡 Full internet routing is disabled for safety.")
+	fmt.Println("   Only VPN subnet (10.0.0.0/24) is routed through the tunnel.")
+	fmt.Println("   Use 'ping 10.0.0.1' to test VPN connectivity.")
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,9 +17,10 @@ type Config struct {
 
 // ServerConfig contains HTTP server settings
 type ServerConfig struct {
-	APIPort       int    `json:"apiPort"`       // HTTP API port (default: 8443)
-	VPNPort       int    `json:"vpnPort"`       // WireGuard UDP port (default: 51820)
-	InterfaceName string `json:"interfaceName"` // WireGuard interface name (default: "wg0")
+	APIPort        int    `json:"apiPort"`        // HTTP API port (default: 8443)
+	VPNPort        int    `json:"vpnPort"`        // WireGuard UDP port (default: 51820)
+	InterfaceName  string `json:"interfaceName"`  // WireGuard interface name (default: "wg0")
+	PublicEndpoint string `json:"publicEndpoint"` // Public endpoint for clients (e.g., "1.2.3.4:51820")
 }
 
 // NetworkConfig contains VPN network settings
@@ -50,9 +51,10 @@ type TestConfig struct {
 func Load() *Config {
 	return &Config{
 		Server: ServerConfig{
-			APIPort:       getEnvInt("PORT", getEnvInt("VPN_API_PORT", 8443)),
-			VPNPort:       getEnvInt("VPN_LISTEN_PORT", 51820),
-			InterfaceName: getEnvString("VPN_INTERFACE", "wg0"),
+			APIPort:        getEnvInt("PORT", getEnvInt("VPN_API_PORT", 8443)),
+			VPNPort:        getEnvInt("VPN_LISTEN_PORT", 51820),
+			InterfaceName:  getEnvString("VPN_INTERFACE", "wg0"),
+			PublicEndpoint: getEnvString("VPN_PUBLIC_ENDPOINT", ""),
 		},
 		Network: NetworkConfig{
 			ServerIP:     getEnvString("VPN_SERVER_IP", "10.0.0.1/24"),

--- a/internal/server/vpnserver/backend.go
+++ b/internal/server/vpnserver/backend.go
@@ -28,6 +28,10 @@ type ServerConfig struct {
 
 	// Server IP within the VPN network (e.g., "10.0.0.1/24")
 	ServerIP string
+
+	// Public endpoint that clients should connect to (e.g., "134.122.48.36:51820")
+	// If empty, defaults to ":port" for localhost testing
+	PublicEndpoint string
 }
 
 // WireGuardBackend defines the interface for different WireGuard implementations

--- a/internal/server/vpnserver/server.go
+++ b/internal/server/vpnserver/server.go
@@ -208,9 +208,15 @@ func (s *VPNServer) GetServerInfo() (ServerInfo, error) {
 		return ServerInfo{}, fmt.Errorf("failed to derive public key: %w", err)
 	}
 
+	// Use PublicEndpoint if configured, otherwise default to localhost format
+	endpoint := s.config.PublicEndpoint
+	if endpoint == "" {
+		endpoint = fmt.Sprintf(":%d", s.config.ListenPort) // Localhost testing
+	}
+
 	return ServerInfo{
 		PublicKey: publicKey,
-		Endpoint:  fmt.Sprintf(":%d", s.config.ListenPort), // Client needs to know port
+		Endpoint:  endpoint,
 		ServerIP:  s.config.ServerIP,
 	}, nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version string = "0.0.12"
+const Version string = "0.0.13"

--- a/internal/wireguard/device.go
+++ b/internal/wireguard/device.go
@@ -25,9 +25,9 @@ func NewWireGuardDevice(interfaceName string) (*WireGuardDevice, error) {
 		return nil, fmt.Errorf("failed to create TUN interface: %w", err)
 	}
 
-	// Create logger for device
+	// Create logger for device - show important events only (handshakes, errors)
 	logger := device.NewLogger(
-		device.LogLevelVerbose,
+		1, // Between Silent and Verbose - shows important events
 		fmt.Sprintf("(%s) ", interfaceName),
 	)
 


### PR DESCRIPTION
## Summary
- Fix VPN server endpoint configuration to return proper remote IP:port instead of :port only
- Fix Windows routing code to work with remote VPN servers (not just localhost testing)
- Update test-vpn command to use VPN tunnel internal IP instead of hardcoded localhost

## Test plan
- [x] Unit tests pass
- [x] Linting passes
- [ ] Deploy updated server to Digital Ocean droplet
- [ ] Test Windows client connection and routing through VPN tunnel
- [ ] Verify ping to 10.0.0.1 works through tunnel
- [ ] Test VPN tunnel functionality end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)